### PR TITLE
Fix nick

### DIFF
--- a/Command/nick.cpp
+++ b/Command/nick.cpp
@@ -67,9 +67,9 @@ void Server::nick(std::stringstream& ss, Client &currClient)
 
 	std::string msg = ":" + oldNick + ADR + currClient.getIPaddr() + " NICK :" + nick;
 
-	std::vector<int> connectedFd;
+	std::set<int> connectedFd;
 	std::map<std::string, Channel>::iterator	itChannel;
-	connectedFd.push_back(currClient.getFd());
+	connectedFd.insert(currClient.getFd());
 	for (itChannel = channels.begin(); itChannel != channels.end(); ++itChannel)
 	{
 		if (itChannel->second.IsUserInChannel(currClient.getFd())) // 해당 사용자가 있는 채널
@@ -77,19 +77,13 @@ void Server::nick(std::stringstream& ss, Client &currClient)
 			std::map<int, Client> clientInChannel = itChannel->second.getClients();
 			std::map<int, Client>::iterator itClient;
 			for (itClient = clientInChannel.begin(); itClient != clientInChannel.end(); ++itClient) //해당 채널의 사용자 순회
-			{
-				if (find(connectedFd.begin(), connectedFd.end(), itClient->first) == connectedFd.end()) // 중복 방지
-					connectedFd.push_back(itClient->first);
-			}
+				connectedFd.insert(itClient->first);
 		}
 	}
 	
-	std::vector<int>::iterator itConnect;
+	std::set<int>::iterator itConnect;
 	for(itConnect = connectedFd.begin(); itConnect != connectedFd.end(); ++itConnect)
-	{
-		std::cout << "user : " << *itConnect << std::endl;
 		pushResponse(*itConnect, msg);
-	}
 
 	std::cout << "success nick\n";
 }

--- a/Command/nick.cpp
+++ b/Command/nick.cpp
@@ -67,12 +67,29 @@ void Server::nick(std::stringstream& ss, Client &currClient)
 
 	std::string msg = ":" + oldNick + ADR + currClient.getIPaddr() + " NICK :" + nick;
 
+	std::vector<int> connectedFd;
 	std::map<std::string, Channel>::iterator	itChannel;
+	connectedFd.push_back(currClient.getFd());
 	for (itChannel = channels.begin(); itChannel != channels.end(); ++itChannel)
 	{
-	
-		if (itChannel->second.IsUserInChannel(currClient.getFd()))
-			sendMsgToChannel(itChannel->first, msg);
+		if (itChannel->second.IsUserInChannel(currClient.getFd())) // 해당 사용자가 있는 채널
+		{
+			std::map<int, Client> clientInChannel = itChannel->second.getClients();
+			std::map<int, Client>::iterator itClient;
+			for (itClient = clientInChannel.begin(); itClient != clientInChannel.end(); ++itClient) //해당 채널의 사용자 순회
+			{
+				if (find(connectedFd.begin(), connectedFd.end(), itClient->first) == connectedFd.end()) // 중복 방지
+					connectedFd.push_back(itClient->first);
+			}
+		}
 	}
+	
+	std::vector<int>::iterator itConnect;
+	for(itConnect = connectedFd.begin(); itConnect != connectedFd.end(); ++itConnect)
+	{
+		std::cout << "user : " << *itConnect << std::endl;
+		pushResponse(*itConnect, msg);
+	}
+
 	std::cout << "success nick\n";
 }


### PR DESCRIPTION
닉네임을 변경한 사용자가 아니어도 닉네임을 변경한 사용자와 같은 채널에 속해있는 사용자라면 응답메시지는 한번만 받도록 동작
닉네임변경 사용자가 속한 채널을 순회하면서 그 채널의 사용자들을 set에 모두 넣어두고 응답메시지를 전송한다