### PR TITLE
fix mode

### DIFF
--- a/Command/mode.cpp
+++ b/Command/mode.cpp
@@ -3,18 +3,6 @@
 #include <utility>
 #include <iostream>
 
-void	Server::userMode(std::stringstream& ss, Client &currClient)
-{
-	//currClient nick과 input이 다를 리는 없겠지?
-	//mode user는 입장 시 그때만 발생?
-	std::string	opInput;
-	if (!(ss >> opInput))
-		;
-	std::string	opMsg = " :" + opInput;
-	std::string	msg = ":" + currClient.getNick() + ADR + currClient.getIPaddr() + " MODE " + currClient.getNick() + opMsg;
-	pushResponse(currClient.getFd(), msg);
-}
-
 bool	Server::useNoOpAndSendMsgInMode(Client currClient, Channel currChannel, std::string channelName)
 {
 	// 사용자에게 mode 변경 권한이 없음 -> ERR_CHANOPRIVSNEEDED(482) 
@@ -35,14 +23,8 @@ void	Server::mode(std::stringstream& ss, Client &currClient)
 	if (!(ss >> channelName))
 		return ;
 
-	if (channelName[0] != '#') // user mode
-	{
-		userMode(ss, currClient);
-		return ;
-	}
-
-	// 채널이 존재하지 않음 -> ERR_NOSUCHCHANNEL
-	if (channels.find(channelName) == channels.end())
+	// 채널이름이 아니거나 존재하지 않는 채널이면 오류
+	if (channelName[0] != '#' || channels.find(channelName) == channels.end())
 	{
 		std::string msg = IL + " " + ERR_NOSUCHCHANNEL + " "+ channelName + " " + ERR_NOSUCHCHANNEL_MSG + "\r\n\r\n";
 		pushResponse(currClient.getFd(), msg);

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -71,7 +71,7 @@ class	Server {
 		void	kick(std::stringstream& ss, Client &currClient);
 		void	mode(std::stringstream& ss, Client &currClient);
 		void	userMode(std::stringstream& ss, Client &currClient);
-
+		bool	useNoOpAndSendMsgInMode(Client currClient, Channel currChannel, std::string channelName);
 };
 //util
 std::vector<std::string> split(const std::string& str, const std::string& delimiter);

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -70,7 +70,6 @@ class	Server {
 		void	ping(std::stringstream& ss, Client currClient);
 		void	kick(std::stringstream& ss, Client &currClient);
 		void	mode(std::stringstream& ss, Client &currClient);
-		void	userMode(std::stringstream& ss, Client &currClient);
 		bool	useNoOpAndSendMsgInMode(Client currClient, Channel currChannel, std::string channelName);
 };
 //util

--- a/Utils/Macro.h
+++ b/Utils/Macro.h
@@ -54,7 +54,7 @@ const std::string ERR_PASSWDMISMATCH_MSG = ":Password incorrect";
 const std::string ERR_CHANNELISFULL = "471";
 const std::string ERR_CHANNELISFULL_MSG = ":Cannot join channel (+l)";
 const std::string ERR_UNKNOWNMODE = "472";
-const std::string ERR_UNKNOWNMODE_MSG = ":is unknown mode char to me";
+const std::string ERR_UNKNOWNMODE_MSG = ":is not a recognised channel mode.";
 const std::string ERR_INVITEONLYCHAN = "473";
 const std::string ERR_INVITEONLYCHAN_MSG = ":Cannot join channel (+i)";
 const std::string ERR_BADCHANNELKEY = "475";
@@ -64,6 +64,6 @@ const std::string ERR_CHANOPRIVSNEEDED_MSG = ":You're not channel operator";
 const std::string ERR_INVALIDMODEPARAM = "696";
 const std::string ERR_INVALIDMODEPARAM_MSG_LIMIT = " l * :You must specify a parameter for the limit mode. Syntax: <limit>.";
 const std::string ERR_INVALIDMODEPARAM_MSG_KEY = " k * :You must specify a parameter for the key mode. Syntax: <key>.";
-const std::string ERR_INVALIDMODEPARAM_MSG_NICK = " o * :You must specify a parameter for the nick mode. Syntax: <nick>.";
+const std::string ERR_INVALIDMODEPARAM_MSG_NICK = " o * :You must specify a parameter for the op mode. Syntax: <nick>.";
 
 #endif


### PR DESCRIPTION
- mode에서 존재하는 옵션인 경우에만 chan op 확인 후 에러 메시지 전송으로 변경, 존재하지 않는 옵션이면 op에러가 아닌 존재하지 않는 옵션이라는 응답을 전송하도록 수정
- 무조건 채널 모드만 존재한다는 가정, #이 안붙으면 존재하지 않는 채널 오류 응답으로 수정
